### PR TITLE
Add a new parameter to integrate Redux snippets in the Container component

### DIFF
--- a/bin/reacli.js
+++ b/bin/reacli.js
@@ -96,6 +96,7 @@ const parseIndex = (componentName) => {
 	return data.replace(/MyComponent/gu, componentName)
 }
 
+// FLOW
 const flowContainerTags = {
 	"flow-component-typing": "<Props, State>",
 	"flow-declaration": "// @flow",
@@ -147,6 +148,36 @@ const dismissFlowOption = (dumbString, containerString) => {
 	]
 }
 
+
+// REDUX
+const reduxContainerFlags = {
+	"redux-import-connect": "import { connect } from 'react-redux';",
+	"redux-map-dispatch-to-props": "const mapDispatchToProps = dispatch => ({\n\t// action: (input) => dispatch(action(input)),\n});",
+	"redux-map-state-to-props": "const mapStateToProps = () => ({}); // or (state) => ({});",
+}
+
+const applyReduxOption = (containerString, componentName) => {
+	for (let key in reduxContainerFlags) {
+		containerString = containerString.replace(new RegExp(`\\[\\[${key}\\]\\]`, "u"), reduxContainerFlags[key])
+	}
+	containerString = containerString.replace(new RegExp(`\\[\\[redux-connection\\]\\]${componentName}Container`, "u"), `connect(mapStateToProps, mapDispatchToProps)(${componentName}Container)`)
+
+	return containerString
+}
+
+const dismissReduxOption = (containerString) => {
+	for (let key in reduxContainerFlags) {
+		containerString = containerString.replace(new RegExp(`\\[\\[${key}\\]\\]`, "u"), "").trim()
+	}
+	containerString = containerString.replace(new RegExp("\\[\\[redux-connection\\]\\]", "u"), "")
+
+	// Remove empty lines
+	containerString = containerString.replace(/^\s*[\r\n\n]/gmu, "\n")
+
+	return containerString
+}
+
+
 const createComponent = (path, options) => {
 	const folderName = getFolderName(path)
 	const componentName = makeComponentName(folderName)
@@ -168,6 +199,13 @@ const createComponent = (path, options) => {
 		[dumbString, containerString] = dismissFlowOption(dumbString, containerString)
 	}
 
+	if (options.redux) {
+		containerString = applyReduxOption(containerString, componentName)
+		console.log("Redux option activated !")
+	} else {
+		containerString = dismissReduxOption(containerString)
+	}
+
 	if (options.scss) {
 		dumbString = dumbString.replace(new RegExp(`./${componentName}.css`, "u"), `./${componentName}.scss`)
 	}
@@ -182,12 +220,16 @@ const reactCli = (args) => {
 	let options = {}
 	const useFlow = (/--flow|-f/u).test(args)
 	const useScss = (/--scss/u).test(args)
+	const useRedux = (/--redux|-r/u).test(args)
 
 	if (useFlow) {
 		options = Object.assign(options, { flow: true })
 	}
 	if (useScss) {
 		options = Object.assign(options, { scss: true })
+	}
+	if (useRedux) {
+		options = Object.assign(options, { redux: true })
 	}
 
    // Cmd reacli component <path> creates a component architecture

--- a/dist/patterns/my-component/components/MyComponentContainer.template
+++ b/dist/patterns/my-component/components/MyComponentContainer.template
@@ -4,6 +4,8 @@ import React, { Component } from "react";
 
 import MyComponent from "./MyComponent";
 
+[[redux-import-connect]]
+
 [[flow-props-type]]
 
 [[flow-state-type]]
@@ -25,4 +27,8 @@ class MyComponentContainer extends Component[[flow-component-typing]] {
   }
 }
 
-export default MyComponentContainer;
+[[redux-map-state-to-props]]
+
+[[redux-map-dispatch-to-props]]
+
+export default [[redux-connection]]MyComponentContainer;

--- a/patterns/my-component/components/MyComponentContainer.template
+++ b/patterns/my-component/components/MyComponentContainer.template
@@ -4,6 +4,8 @@ import React, { Component } from "react";
 
 import MyComponent from "./MyComponent";
 
+[[redux-import-connect]]
+
 [[flow-props-type]]
 
 [[flow-state-type]]
@@ -25,4 +27,8 @@ class MyComponentContainer extends Component[[flow-component-typing]] {
   }
 }
 
-export default MyComponentContainer;
+[[redux-map-state-to-props]]
+
+[[redux-map-dispatch-to-props]]
+
+export default [[redux-connection]]MyComponentContainer;


### PR DESCRIPTION
# Fixes issue #3 

**Summary:**

Generate some snippets related to Redux in the _Container_ component such as:

* import the `connect` function
* define the `mapStateToProps` and  `mapDispatchToProps` functions
* connect the component to the Redux store

**Changes:**

* `patterns/my-component/components/MyComponentContainer.template`: add Redux related tags for places where Redux snippets should be inserted
* `bin/reacli.js`: add the `--redux` (or `-r`) argument to parse the container and insert the Redux snippets

**Dependencies:**

No dependency

**Instructions:**

To test it, just runs the CLI to create a new component by adding the `--redux` (or `-r`) argument. See the generated _Container_ component (it shouldn't have any impact on the _Dumb_ component).

You can also check that when not using this argument, Redux related tags are well removed from the generated _Container_.

Finally, you can also try to use both `--redux` and `--flow` and check that both options can be used simultaneously.
