### PR TITLE
docs: change homepage to precise the landing website on the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "bugs": {
     "url": "https://github.com/reacli/cli/issues"
   },
-  "homepage": "https://github.com/reacli/cli#readme",
+  "homepage": "https://reacli.github.io/",
   "devDependencies": {
     "@commitlint/cli": "^7.0.0",
     "@commitlint/config-conventional": "^7.0.1",


### PR DESCRIPTION
# Fixes issue #27 

**Summary:**

To add the website landing page to the NPM package, I changed `homepage` in `package.json`.

**Changes :** 

- `package.json`: update the `homepage` field

**Dependencies:**

No dependency

**Instructions:**

I removed "https://github.com/reacli/cli#readme" and  added "https://reacli.github.io/" at `homepage`.
```
  "homepage": "https://github.com/reacli/cli#readme",
```


Am I right?

I'm newbie.. If I did wrong, Plz feedback me!

Thank U :)
