### PR TITLE
Reacli config file (.reacli) to load project options 

### DIFF
--- a/bin/reacli.js
+++ b/bin/reacli.js
@@ -8,7 +8,7 @@ import { validateName, validatePath } from "../lib/utils/validators"
 import { createComponent } from "../lib/core"
 
 
-const reactCli = () => {
+const reactCli = async () => {
 
 	pkgInfo(module, "version");
 	const cliVersion = module.exports.version;
@@ -42,7 +42,7 @@ const reactCli = () => {
 
 		if (validatePath(path) && validateName(path)) {
 			try {
-				createComponent(path, options)
+				await createComponent(path, options)
 			} catch (error) {
 				console.log("ERROR: ", error)
 				program.outputHelp()

--- a/lib/core.js
+++ b/lib/core.js
@@ -20,7 +20,7 @@ const createComponent = async (path, options) => {
 
 	if (reacliConfigFileExists) {
 		console.log(`Reacli configuration file found at '${packageRootDir}'.`)
-		options = JSON.parse(fs.readFileSync(`${packageRootDir}/.reacli`, "utf8"))
+		options = Object.assign(options, JSON.parse(fs.readFileSync(`${packageRootDir}/.reacli`, "utf8")))
 	}
 
 	// MkdirSync recursive not working

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,17 +2,26 @@
 import Mustache from "mustache"
 import fs from "fs"
 import pathModule from "path"
+import pkgDir from "pkg-dir"
 
 import cleanUp from "./utils/clean_up"
 import { getFolderName, makeComponentName, createFiles, prepareFiles } from "./utils/files"
 import { addFlowOption } from "./flow"
 import { addReduxOption } from "./redux"
 
-const createComponent = (path, options) => {
+const createComponent = async (path, options) => {
 	const folderName = getFolderName(path)
 	const componentName = makeComponentName(folderName)
 
 	const componentsPath = pathModule.resolve(path, "components")
+
+	const packageRootDir = await pkgDir(__dirname);
+	const reacliConfigFileExists = fs.existsSync(`${packageRootDir}/.reacli`)
+
+	if (reacliConfigFileExists) {
+		console.log(`Reacli configuration file found at '${packageRootDir}'.`)
+		options = JSON.parse(fs.readFileSync(`${packageRootDir}/.reacli`, "utf8"))
+	}
 
 	// MkdirSync recursive not working
 	fs.mkdirSync(path)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reacli",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6803,8 +6803,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -6864,7 +6863,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "dev": true,
       "requires": {
         "find-up": "^3.0.0"
       },
@@ -6873,7 +6871,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
           }
@@ -6882,7 +6879,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
@@ -6892,7 +6888,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
           "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -6901,7 +6896,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
           }
@@ -6909,8 +6903,7 @@
         "p-try": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-          "dev": true
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "rimraf": "^2.6.3"
   },
   "dependencies": {
-    "is-windows": "^1.0.2",
     "commander": "^2.19.0",
-    "pkginfo": "^0.4.1",
-    "mustache": "^3.0.1"
+    "is-windows": "^1.0.2",
+    "mustache": "^3.0.1",
+    "pkg-dir": "^3.0.0",
+    "pkginfo": "^0.4.1"
   }
 }


### PR DESCRIPTION
# Fixes issue #13 

**Summary:**

Some users might want to use the _Reacli_ CLI to create several components in the same project. Each component might have to be configured with the same options. For example, if the project uses _Flow_ for one component, I bet the user will want to use the same option for every component he creates thanks to the CLI.

I then created a feature enabling the user to add a `.reacli` file at the root of the project. 

The CLI will then find the root of the project and check if there is a `.reacli` file there. If that is the case, it will load it and add its content to the options given at runtime.

For example, let's imagine there is a `.reacli` file like the following.

```json
{
  "flow": true,
  "scss": true
}
```

If the user calls 

```bash
reacli component ./my-super-component --redux
```

The generated component will use the following options:

- _Flow_
- _SCSS_
- _Redux_

**Changes:**

* `bin/reacli.js`: the `reactCli` function is now async and calls `createComponent` that is also async 
* `lib/core.js`: loads the options written in `.reacli` if it exists and add it to the options given to the CLI at runtime
* `package.json`: add a dependency to `pkg-dir`

**Dependencies:**

No dependency

**Instructions:**

Try to create a `.reacli` file at the root of a project, create a component with the CLI and optionally add an option at runtime, and see if it is created with all the options you would like 😊 