### PR TITLE
Fix: changes current dir path

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -15,7 +15,7 @@ const createComponent = async (path, options) => {
 
 	const componentsPath = pathModule.resolve(path, "components")
 
-	const packageRootDir = await pkgDir(__dirname);
+	const packageRootDir = await pkgDir(path);
 	const reacliConfigFileExists = fs.existsSync(`${packageRootDir}/.reacli`)
 
 	if (reacliConfigFileExists) {


### PR DESCRIPTION
# Fixes path given to project-dir finder

**Summary:**

Wrong variable was used to get the user's current project's root dir. This is a fix.

**Changes:**

* Changes variable used in `pkg-dir`

**Dependencies:**

No dependency