### PR TITLE
Use the CLI to create several components at once

### DIFF
--- a/bin/reacli.js
+++ b/bin/reacli.js
@@ -21,9 +21,9 @@ const reactCli = async () => {
 		.option("--redux", "Add Redux to the template")
 		.parse(process.argv)
 
-	const { args } = program;
-	const firstParam = args.shift();
-	const secondParam = args.shift();
+	const { args } = program
+	const firstParam = args.shift()
+	const pathsToComponentsToCreate = args
 
 	let options = {}
 	if (program.flow) {
@@ -38,16 +38,21 @@ const reactCli = async () => {
 
 	// Cmd reacli component <path> creates a component architecture
 	if (firstParam === "component") {
-		const path = pathModule.resolve(secondParam)
+		const promises = []
+		for (let relativePath of pathsToComponentsToCreate) {
+			const path = pathModule.resolve(relativePath)
 
-		if (validatePath(path) && validateName(path)) {
-			try {
-				await createComponent(path, options)
-			} catch (error) {
-				console.log("ERROR: ", error)
-				program.outputHelp()
+			if (validatePath(path) && validateName(path)) {
+				try {
+					promises.push(createComponent(path, options))
+				} catch (error) {
+					console.log("ERROR: ", error)
+					program.outputHelp()
+				}
 			}
 		}
+
+		await Promise.all(promises)
 	}
 }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -19,7 +19,7 @@ const createComponent = async (path, options) => {
 	const reacliConfigFileExists = fs.existsSync(`${packageRootDir}/.reacli`)
 
 	if (reacliConfigFileExists) {
-		console.log(`Reacli configuration file found at '${packageRootDir}'.`)
+		console.log(`[${componentName}] Reacli configuration file found at '${packageRootDir}'.`)
 		options = Object.assign(options, JSON.parse(fs.readFileSync(`${packageRootDir}/.reacli`, "utf8")))
 	}
 
@@ -36,12 +36,12 @@ const createComponent = async (path, options) => {
 
 	if (options.flow) {
 		[dumbTags, containerTags] = addFlowOption(dumbTags, containerTags, componentName)
-		console.log("Flow option activated !")
+		console.log(`[${componentName}] Flow option activated !`)
 	}
 
 	if (options.redux) {
 		containerTags = addReduxOption(containerTags, componentName)
-		console.log("Redux option activated !")
+		console.log(`[${componentName}] Redux option activated !`)
 	}
 
 	if (options.scss) {

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -32,7 +32,7 @@ const createFiles = (path, componentName, dumbString, containerString, indexStri
 			throw err
 		}
 
-		console.log("Index created !")
+		console.log(`[${componentName}] Index created !`)
 	})
 
 	fs.writeFile(dumbComponentPath, dumbString, "utf8", (err) => {
@@ -40,7 +40,7 @@ const createFiles = (path, componentName, dumbString, containerString, indexStri
 			throw err
 		}
 
-		console.log("Dumb component created !")
+		console.log(`[${componentName}] Dumb component created !`)
 	})
 
 	fs.writeFile(containerPath, containerString, "utf8", (err) => {
@@ -48,7 +48,7 @@ const createFiles = (path, componentName, dumbString, containerString, indexStri
 			throw err
 		}
 
-		console.log("Container component created !")
+		console.log(`[${componentName}] Container component created !`)
 	})
 
 	fs.writeFile(styleSheetPath, "", "utf8", (err) => {
@@ -56,7 +56,7 @@ const createFiles = (path, componentName, dumbString, containerString, indexStri
 			throw err
 		}
 
-		console.log("StyleSheet created !")
+		console.log(`[${componentName}] StyleSheet created !`)
 	})
 }
 

--- a/lib/utils/validators.js
+++ b/lib/utils/validators.js
@@ -1,14 +1,14 @@
 
 // Validate name
 const validateName = (path) => {
-	console.log(`Valid: ${path}`)
+	console.log(`Valid name: ${path}`)
 
 	return true
 }
 
 // Validate path
 const validatePath = (path) => {
-	console.log(`Valid: ${path}`)
+	console.log(`Valid path: ${path}`)
 
 	return true
 }


### PR DESCRIPTION
# Fixes #38 

**Summary:**

I added a feature enabling to create several components in one single command line.

To use it, you have to precise several paths to the components to create:

```bash
reacli component ./path-to-comp1 ./path-to-comp2
```

You can still add options after the paths (like `--flow`...). Those options will be applied to each component that will be generated.

Moreover, if a `.reacli` file is present, it will be used for each of the components to create.

**Changes:**

* `bin/reacli.js`: loop on paths to create possibly multiple components (and take full advantage of the parallelization benefits with the usage of a `Promise.all([])` call)
* `lib/core.js`: for log lines, write which component it concerns
* `lib/utils/files.js`: for log lines, write which component it concerns
* `lib/utils/validators.js`: distinguish logs between the different validation methods

**Dependencies:**

No dependency

**Instructions:**

Try to run the following command:

```bash
reacli component ./path-to-comp1 ./path-to-comp2
```

You can also ttry adding options at the end of the CLI or create a `.reacli` file 😊 
