### PR TITLE
docs: bump version to 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reacli",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A simple and straightforward React boilerplate CLI",
   "main": "./dist/bin/reacli.js",
   "scripts": {


### PR DESCRIPTION
# Bump version to 1.5.2

**Summary:**

Bump version to 1.5.2 to republish it.

**Changes:**

* `package.json`: bump version to 1.5.2

**Dependencies:**

No dependency