### PR TITLE
fix: too heavy build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "precommit": "npm run lint && npm run build && npm run test",
     "test": "jest --config ./config/jest.config.js",
-    "build": "rimraf dist/ && babel ./ --out-dir dist/ --ignore ./node_modules,./test,./.babelrc,./package.json,./package-lock.json,./npm-debug.log,./README.md,./CONTRIBUTING.md,./commitlint.config.js --copy-files",
+    "build": "rimraf dist/ && babel ./ --out-dir dist/ --ignore ./node_modules,./test,./config,./commitlint.config.js && cp -r patterns dist/",
     "prepublishOnly": "npm run build",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint ./bin/*.js"


### PR DESCRIPTION
# Fixes: Build is too heavy #58

**Summary:**

Build contains ignored folders like node_modules, which makes it much more heavier than it should.

**Changes:**

* Removed useless files  & folders from build.

