### PR TITLE
refactor: using if - else instead of switch - case in commands selection

### DIFF
--- a/bin/reacli.js
+++ b/bin/reacli.js
@@ -19,16 +19,12 @@ const createElement = async ({ firstParam = null, pathsToComponentsToCreate = []
 
 		if (validatePath(path) && validateName(path)) {
 			try {
-				switch (firstParam) {
-				case "component":
+				if (firstParam === "component") {
 					promises.push(createComponent(path, options))
-					break;
-				case "hook":
+				} else if (firstParam === "hook") {
 					promises.push(createHook(path, options))
-					break;
-				default:
+				} else {
 					program.outputHelp()
-					break;
 				}
 			} catch (error) {
 				console.log("ERROR: ", error)


### PR DESCRIPTION
# Fixes [Enhancement in the source code switch - case] #73 

**Summary:**

To easily add new commands, the `switch-case` sentence was replaced by an` if - else if`

**Changes:**

* Using `if - else if` instead of `switch - case` > https://github.com/reacli/cli/blob/develop/bin/reacli.js#L22

**Dependencies:**

No dependency
